### PR TITLE
Feature/505 hot reload

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,16 @@
 {
   "name": "serverless-offline-edge-lambda",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.2.0",
+      "name": "serverless-offline-edge-lambda",
+      "version": "1.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "body-parser": "^1.19.0",
+        "chokidar": "^3.5.3",
         "connect": "^3.7.0",
         "cookie-parser": "^1.4.5",
         "flat-cache": "^3.0.4",
@@ -3176,7 +3178,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
       "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
-      "peer": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -3483,7 +3484,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -4017,10 +4017,15 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
-      "peer": true,
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -7221,7 +7226,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "peer": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -8486,7 +8490,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11276,6 +11279,11 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12508,7 +12516,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "peer": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -17886,7 +17893,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
       "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
-      "peer": true,
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -18151,8 +18157,7 @@
     "binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-      "peer": true
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
     },
     "bindings": {
       "version": "1.5.0",
@@ -18584,10 +18589,9 @@
       }
     },
     "chokidar": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
-      "peer": true,
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
       "requires": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -21186,7 +21190,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "peer": true,
       "requires": {
         "binary-extensions": "^2.0.0"
       }
@@ -22231,8 +22234,7 @@
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "peer": true
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
     },
     "normalize-url": {
       "version": "6.1.0",
@@ -25052,7 +25054,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "peer": true,
       "requires": {
         "picomatch": "^2.2.1"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-offline-edge-lambda",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A plugin for the Serverless Framework that simulates the behavior of AWS CloudFront Edge Lambdas while developing offline.",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -49,6 +49,7 @@
   ],
   "dependencies": {
     "body-parser": "^1.19.0",
+    "chokidar": "^3.5.3",
     "connect": "^3.7.0",
     "cookie-parser": "^1.4.5",
     "flat-cache": "^3.0.4",

--- a/src/behavior-router.ts
+++ b/src/behavior-router.ts
@@ -31,7 +31,7 @@ export class BehaviorRouter {
 	private builder: ConfigBuilder;
 	private context: Context;
 	private behaviors = new Map<string, FunctionSet>();
-	private cfResources: Record<string, CFDistribution>;
+	private cfResources:  Record<string, CFDistribution>;
 
 	private cacheDir: string;
 	private fileDir: string;
@@ -180,7 +180,7 @@ export class BehaviorRouter {
 
 				try {
 					const lifecycle = new CloudFrontLifecycle(this.serverless, this.options, cfEvent,
-						this.context, this.cacheService, handler, customOrigin);
+																this.context, this.cacheService, handler, customOrigin);
 					const response = await lifecycle.run(req.url as string);
 
 					if (!response) {
@@ -192,10 +192,7 @@ export class BehaviorRouter {
 
 					const helper = new CloudFrontHeadersHelper(response.headers);
 
-					for (const {
-						key,
-						value
-					} of helper.asHttpHeaders()) {
+					for (const { key, value } of helper.asHttpHeaders()) {
 						if (value) {
 							res.setHeader(key as string, value);
 						}
@@ -275,8 +272,8 @@ export class BehaviorRouter {
 			// Don't try to register distributions that come from other sources
 			if (fnSet.distribution !== distribution) {
 				this.log(`Warning: pattern ${pattern} has registered handlers for cf distributions ${fnSet.distribution}` +
-					` and ${distribution}. There is no way to tell which distribution should be used so only ${fnSet.distribution}` +
-					` has been registered.`);
+						` and ${distribution}. There is no way to tell which distribution should be used so only ${fnSet.distribution}` +
+						` has been registered.` );
 				continue;
 			}
 

--- a/src/utils/debounce.ts
+++ b/src/utils/debounce.ts
@@ -1,0 +1,22 @@
+export const debounce =
+	function (func: { (eventName: any, srcPath: any): Promise<void>; apply?: any; }, threshold: number, execAsap: boolean) {
+	let timeout: any;
+	return function debounced(this: any) {
+		const obj = this;
+		const args = arguments;
+
+		function delayed() {
+			if (!execAsap) {
+				func.apply(obj, args);
+			}
+			timeout = undefined;
+		}
+
+		if (timeout) {
+			clearTimeout(timeout);
+		} else if (execAsap) {
+			func.apply(obj, args);
+		}
+		timeout = setTimeout(delayed, threshold || 100);
+	};
+};

--- a/src/utils/load-module.ts
+++ b/src/utils/load-module.ts
@@ -1,5 +1,5 @@
 import { resolve } from 'path';
-import {clearModule} from './clear-module';
+import { clearModule } from './clear-module';
 
 export class ModuleLoader {
 	protected loadedModules: string[] = [];
@@ -15,6 +15,7 @@ export class ModuleLoader {
 		const [, modulePath, functionName] = match;
 		const absPath = resolve(modulePath);
 
+		delete require.cache[require.resolve(absPath)];
 		const module = await import(absPath);
 
 		this.loadedModules.push(absPath);


### PR DESCRIPTION
### Hot Reload

This is a fix for issue #505, hot reload not working.

The solution applied here is to use chokidar to watch files in the distribution/bundle folder, wether that be esbuild, webpack, or typescript doing the build. 

Upon a rebuild, the node.js require cache is busted for the changed handler 'extractBehaviors()' is re-called to reload the handlers. The reload is via an import statement which caches imported code, so a cache bust is required for the newly compiled/bundled code to be loaded.

Chokidar is debounced so that the handlers are reloaded at the end of a build. Any file in the directory specified by the "path" option will be watched and if changed hot-reloaded. Note that the default path is the current directory (".").

I use esbuild and have not tested this with typescript based builds, but the same principles will apply and it should work.

The watch/reload mechanism is disabled by default so that current usage is unchanged. The flag "watchReload: true" will turn on the watcher so that typescript and esbuild solutions use the watcher to hot reload the handlers.

example:
```
   offlineEdgeLambda: {
      path: '.esbuild/.build',
      watchReload: true,
    },
```

Additional options can be used to modify the behavior of the file watcher and debounce logic (ignoreInitial, awaitWriteFinish, interval, debounce). 

For example:
```
   offlineEdgeLambda: {
      path: '.esbuild/.build',
      watchReload: true,
      ignoreInitial: true,
      awaitWriteFinish: true,
      interval: 500,
      debounce: 750,
   },
```

Implementations using webpack appears to have a solution already in place for hot reload. However, my experimentation with the server restart mechanism used by the webpack solution's onReload() function appears to not work very well. It might be better for the onReload() to call extractBehaviors() instead of server.restart(). This could be implemented in a future pull request.



